### PR TITLE
[#2] Matrix order in multipy

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -109,16 +109,16 @@ Matrix.subtract = function(m1, m2) {
  */
 
 Matrix.multiply = function(m1, m2) {
-  var result = Matrix({ rows: m2.numRows, columns: m1.numCols });
+  var result = Matrix({ rows: m1.numRows, columns: m2.numCols });
 
-  for (var i = 0; i < m2.numRows; i++) {
+  for (var i = 0; i < m1.numRows; i++) {
     result[i] = [];
 
-    for (var j = 0; j < m1.numCols; j++) {
+    for (var j = 0; j < m2.numCols; j++) {
       var sum = 0;
 
-      for (var k = 0; k < m1.numRows; k++) {
-        sum += m1[k][j] * m2[i][k];
+      for (var k = 0; k < m1.numCols; k++) {
+        sum += m2[k][j] * m1[i][k];
       }
 
       result[i][j] = sum;

--- a/test/index.js
+++ b/test/index.js
@@ -148,14 +148,14 @@ describe('Matrix()', function() {
   describe('#multiply()', function() {
     it('should perform multiplication on two matrices with appropriate dimensions', function() {
       var matrixOne = Matrix([
-        [5, 3, 6],
-        [7, 4, 3]
-      ]);
-
-      var matrixTwo = Matrix([
         [4, 1],
         [9, 4],
         [3, 1]
+      ]);
+
+      var matrixTwo = Matrix([
+        [5, 3, 6],
+        [7, 4, 3]
       ]);
 
       var result = Matrix.multiply(matrixOne, matrixTwo);


### PR DESCRIPTION
`Matrix#multiply` inputs are reversed, as described in https://github.com/stevenmiller888/matrix/issues/2.

This PR fixes this and makes `Matrix#multiply` comply with the mathematical definition of the operation.