### PR TITLE
Matrix multiplication validation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -109,16 +109,16 @@ Matrix.subtract = function(m1, m2) {
  */
 
 Matrix.multiply = function(m1, m2) {
-  var result = Matrix({ rows: m2.numRows, columns: m1.numCols });
+  var result = Matrix({ rows: m1.numRows, columns: m2.numCols });
 
-  for (var i = 0; i < m2.numRows; i++) {
+  for (var i = 0; i < m1.numRows; i++) {
     result[i] = [];
 
-    for (var j = 0; j < m1.numCols; j++) {
+    for (var j = 0; j < m2.numCols; j++) {
       var sum = 0;
 
-      for (var k = 0; k < m1.numRows; k++) {
-        sum += m1[k][j] * m2[i][k];
+      for (var k = 0; k < m1.numCols; k++) {
+        sum += m2[k][j] * m1[i][k];
       }
 
       result[i][j] = sum;

--- a/lib/index.js
+++ b/lib/index.js
@@ -109,6 +109,10 @@ Matrix.subtract = function(m1, m2) {
  */
 
 Matrix.multiply = function(m1, m2) {
+  if (m1.numCols !== m2.numRows) {
+    throw new Error('You can only multiply matrices with compatible dimensions');
+  }
+
   var result = Matrix({ rows: m1.numRows, columns: m2.numCols });
 
   for (var i = 0; i < m1.numRows; i++) {

--- a/test/index.js
+++ b/test/index.js
@@ -148,14 +148,14 @@ describe('Matrix()', function() {
   describe('#multiply()', function() {
     it('should perform multiplication on two matrices with appropriate dimensions', function() {
       var matrixOne = Matrix([
-        [5, 3, 6],
-        [7, 4, 3]
-      ]);
-
-      var matrixTwo = Matrix([
         [4, 1],
         [9, 4],
         [3, 1]
+      ]);
+
+      var matrixTwo = Matrix([
+        [5, 3, 6],
+        [7, 4, 3]
       ]);
 
       var result = Matrix.multiply(matrixOne, matrixTwo);

--- a/test/index.js
+++ b/test/index.js
@@ -170,6 +170,21 @@ describe('Matrix()', function() {
       assert.equal(result[2][1], 13);
       assert.equal(result[2][2], 21);
     });
+
+    it('should not perform multiplication on two matrices with incompatible dimensions', function() {
+      var matrixOne = Matrix([
+        [0, 0],
+        [0, 0]
+      ]);
+
+      var matrixTwo = Matrix([
+        [0, 0],
+        [0, 0],
+        [0, 0]
+      ]);
+
+      assert.throws(function(){ Matrix.multiply(matrixOne, matrixTwo) }, /You can only multiply matrices with compatible dimensions/)
+    });
   });
 
   describe('#multiplyScalar()', function() {


### PR DESCRIPTION
According to the mathematical definition, two matrices may be multiplied only if the first one has as many columns as the second one has rows.

This PR adds this validation.

(based on https://github.com/stevenmiller888/matrix/pull/3)